### PR TITLE
Fix pnpm setup order for caching

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -52,17 +52,17 @@ jobs:
           name: wasm-pkg
           path: pkg
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install web dependencies
         working-directory: web


### PR DESCRIPTION
## Summary
- Install pnpm before setup-node so pnpm cache can be restored

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68bc0f0b77a8832ca4afb419c4f090ef