### PR TITLE
Add rectangular board support and update k10 puzzle

### DIFF
--- a/puzzle-wasm/src/lib.rs
+++ b/puzzle-wasm/src/lib.rs
@@ -1277,6 +1277,16 @@ fn board_to_geom(board: &Board) -> Option<Vec<Point>> {
                 ])
             }
         }
+        Some("rect") => {
+            let w = board.w.unwrap_or(0.0);
+            let h = board.h.unwrap_or(0.0);
+            Some(vec![
+                Point { x: 0.0, y: 0.0 },
+                Point { x: w, y: 0.0 },
+                Point { x: w, y: h },
+                Point { x: 0.0, y: h },
+            ])
+        }
         Some("polygon") => {
             let pts = board
                 .points
@@ -1398,6 +1408,25 @@ fn board_outer_geom(board: &Board, ring: f64) -> Option<Vec<Point>> {
                 y: h + ring,
             });
             Some(pts)
+        }
+        Some("rect") => {
+            let w = board.w.unwrap_or(0.0);
+            let h = board.h.unwrap_or(0.0);
+            Some(vec![
+                Point { x: -ring, y: -ring },
+                Point {
+                    x: w + ring,
+                    y: -ring,
+                },
+                Point {
+                    x: w + ring,
+                    y: h + ring,
+                },
+                Point {
+                    x: -ring,
+                    y: h + ring,
+                },
+            ])
         }
         Some("polygon") => {
             // Rounded outward offset of the given polygon by `ring` using

--- a/puzzle/k10.json
+++ b/puzzle/k10.json
@@ -1,11 +1,9 @@
 {
   "units": "mm",
   "board": {
-    "type": "rect_with_quarter_round_cut",
+    "type": "rect",
     "w": 125,
     "h": 99,
-    "cut_corner": "no",
-    "r": 0,
     "label_zh": "外框 125×99mm",
     "label_en": "Board 125×99mm"
   },
@@ -15,5 +13,5 @@
     "rt_30x60": 6
   },
   "note_zh": "请将所有拼块放入外框内，彼此不可重叠；允许留空，不必完全填满。完成拼图后，外框必须是一个矩形（手动验证）。",
-  "note_en": "Place all pieces inside the frame. No overlaps. Leaving gaps is allowed."
+  "note_en": "Place all pieces inside the frame. No overlaps. Leaving gaps is allowed. After completion, the frame must form a rectangle (manual check)."
 }


### PR DESCRIPTION
## Summary
- Support plain rectangular boards in puzzle-wasm
- Convert k10 board to rectangle and clarify English description

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bc401c2f20832c8ccb45791711587e